### PR TITLE
added the license type to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "easing",
   "version": "1.2.1",
+  "license": "MIT",
   "description": "Easing Functions Without the Framework Cruft",
   "author": "David Wee <rook2pawn@gmail.com> (http://rook2pawn.com)",
   "contributors": [


### PR DESCRIPTION
For a project i'm working on it helps me to have all my dependencies explicitly state their license type in the package.json.